### PR TITLE
feat: bootstrap habit rpg starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# rpg-habit-tracking
+# Habit RPG Starter
+
+Un starter de jeu "Habit RPG" construit avec React 18, TypeScript, Vite, Tailwind et Zustand.
+
+## Installation
+
+```bash
+npm install
+npm run dev
+```
+
+## Scripts
+
+- `npm run dev` : lance le serveur de développement
+- `npm run build` : build de production
+- `npm run preview` : prévisualisation du build
+- `npm run lint` : vérifie le code avec ESLint
+
+## Gameplay
+
+- Créez des habitudes et complétez des quêtes quotidiennes pour gagner de l'XP et de l'or.
+- XP : 10 par habitude (multiplicateur selon la difficulté), 15 par quête.
+- Or : 2 par habitude, 5 par quête.
+- Niveaux : `xpNeeded(level) = 100 + (level - 1) * 25` avec bonus de 10 or par niveau.
+- Streaks remis à zéro si un jour est manqué. Si aucune action n'est faite sur une journée, -5 HP.
+
+## Structure
+
+- `src/app` : entrée de l'application et router
+- `src/components` : composants UI réutilisables
+- `src/pages` : pages associées aux routes
+- `src/store` : stores Zustand avec persistance localStorage
+- `src/utils` : fonctions utilitaires
+- `src/types` : types TypeScript
+- `src/styles` : styles Tailwind
+
+## Roadmap
+
+- v2 : boss hebdomadaire, guildes/amis
+- v3 : historique détaillé, analytics, export CSV
+- TODO : auth & sync cloud, IAP réelles, thèmes premium

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactPlugin from 'eslint-plugin-react';
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooks.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      react: { version: '18.0' },
+    },
+  },
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Habit RPG</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/app/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "habit-rpg",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.18.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@typescript-eslint/eslint-plugin": "^6.4.0",
+    "@typescript-eslint/parser": "^6.4.0",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.45.0",
+    "eslint-plugin-react": "^7.33.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^3.1.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import Router from './router';
+import '../styles/index.css';
+import { useGameStore } from '../store/gameStore';
+import { useHabitsStore } from '../store/habitsStore';
+import { useQuestsStore } from '../store/questsStore';
+
+function Init() {
+  const dailyDecayIfIdle = useGameStore(s => s.dailyDecayIfIdle);
+  const resetHabits = useHabitsStore(s => s.resetDailyChecksIfNewDay);
+  const ensureQuests = useQuestsStore(s => s.ensureDailyQuests);
+
+  React.useEffect(() => {
+    dailyDecayIfIdle();
+    resetHabits();
+    ensureQuests();
+  }, [dailyDecayIfIdle, resetHabits, ensureQuests]);
+
+  return <Router />;
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Init />
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,21 @@
+import { Routes, Route } from 'react-router-dom';
+import Layout from '../components/Layout';
+import Home from '../pages/Home';
+import Habits from '../pages/Habits';
+import Quests from '../pages/Quests';
+import Shop from '../pages/Shop';
+import Profile from '../pages/Profile';
+
+export default function Router() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/habits" element={<Habits />} />
+        <Route path="/quests" element={<Quests />} />
+        <Route path="/shop" element={<Shop />} />
+        <Route path="/profile" element={<Profile />} />
+      </Routes>
+    </Layout>
+  );
+}

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,3 @@
+export default function EmptyState({ message }: { message: string }) {
+  return <p className="text-center text-gray-500">{message}</p>;
+}

--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -1,0 +1,29 @@
+import { Habit } from '../types';
+import { useHabitsStore } from '../store/habitsStore';
+
+function formatLast(ts?: number) {
+  if (!ts) return 'jamais';
+  const diff = Math.floor((Date.now() - ts) / 86400000);
+  if (diff === 0) return "aujourd'hui";
+  if (diff === 1) return 'hier';
+  return `il y a ${diff}j`;
+}
+
+export default function HabitCard({ habit }: { habit: Habit }) {
+  const toggle = useHabitsStore(s => s.toggleCompleteToday);
+  return (
+    <div className="bg-white shadow p-4 rounded mb-2 flex justify-between items-center">
+      <div>
+        <div className="font-semibold">{habit.name}</div>
+        <div className="text-xs text-gray-500">Streak: {habit.streak} – Dernier: {formatLast(habit.lastCompletedAt)}</div>
+      </div>
+      <button
+        aria-label="Fait aujourd'hui"
+        className="px-3 py-1 bg-green-500 text-white rounded"
+        onClick={() => toggle(habit.id)}
+      >
+        Fait
+      </button>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import { Link, NavLink } from 'react-router-dom';
+import { useGameStore } from '../store/gameStore';
+import ProgressBar from './ProgressBar';
+import { xpNeeded } from '../utils/xp';
+
+export default function Header() {
+  const player = useGameStore(s => s.player);
+  const xpMax = xpNeeded(player.level);
+  return (
+    <header className="bg-white shadow sticky top-0 z-10">
+      <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
+        <Link to="/" className="font-bold text-lg">Habit RPG</Link>
+        <nav className="space-x-4">
+          <NavLink to="/habits" className={({isActive})=>isActive?'text-blue-600':'text-gray-600'}>Habits</NavLink>
+          <NavLink to="/quests" className={({isActive})=>isActive?'text-blue-600':'text-gray-600'}>Quests</NavLink>
+          <NavLink to="/shop" className={({isActive})=>isActive?'text-blue-600':'text-gray-600'}>Shop</NavLink>
+          <NavLink to="/profile" className={({isActive})=>isActive?'text-blue-600':'text-gray-600'}>Profile</NavLink>
+        </nav>
+        <div className="flex items-center space-x-2 text-sm">
+          <div className="w-24">
+            <ProgressBar label="XP" color="bg-blue-500" value={player.xp} max={xpMax} />
+          </div>
+          <div className="w-24">
+            <ProgressBar label="HP" color="bg-red-500" value={player.hp} max={player.maxHp} />
+          </div>
+          <div className="font-semibold text-yellow-600">{player.gold}g</div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react';
+import Header from './Header';
+
+export default function Layout({ children }: PropsWithChildren) {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <Header />
+      <main className="p-4 max-w-5xl mx-auto">{children}</main>
+    </div>
+  );
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface Props {
+  label: string;
+  value: number;
+  max: number;
+  color: string;
+}
+
+const ProgressBar: React.FC<Props> = ({ label, value, max, color }) => {
+  const pct = Math.min(100, (value / max) * 100);
+  return (
+    <div className="w-full bg-gray-200 rounded h-3" aria-label={label}>
+      <div className={`${color} h-3 rounded`} style={{ width: `${pct}%` }} />
+      <span className="sr-only">{label} {value}/{max}</span>
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/QuestCard.tsx
+++ b/src/components/QuestCard.tsx
@@ -1,0 +1,22 @@
+import { Quest } from '../types';
+import { useQuestsStore } from '../store/questsStore';
+
+export default function QuestCard({ quest }: { quest: Quest }) {
+  const complete = useQuestsStore(s => s.completeQuest);
+  return (
+    <div className="bg-white shadow p-4 rounded mb-2 flex justify-between items-center">
+      <div>
+        <div className="font-semibold">{quest.title}</div>
+        <div className="text-xs text-gray-500">{quest.description}</div>
+      </div>
+      <button
+        aria-label="Valider la quête"
+        className={`px-3 py-1 rounded ${quest.completed ? 'bg-gray-300' : 'bg-blue-500 text-white'}`}
+        disabled={quest.completed}
+        onClick={() => complete(quest.id)}
+      >
+        {quest.completed ? 'Fait' : 'Valider'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ShopItemCard.tsx
+++ b/src/components/ShopItemCard.tsx
@@ -1,0 +1,22 @@
+import { useShopStore } from '../store/shopStore';
+
+interface Props {
+  item: { id: string; name: string; cost: number; type: string };
+}
+
+export default function ShopItemCard({ item }: Props) {
+  const purchase = useShopStore(s => s.purchase);
+  return (
+    <div className="bg-white shadow p-4 rounded text-center">
+      <div className="font-semibold mb-2">{item.name}</div>
+      <div className="text-sm text-gray-500 mb-2">{item.cost}g</div>
+      <button
+        aria-label="Acheter"
+        className="px-3 py-1 bg-purple-500 text-white rounded"
+        onClick={() => purchase(item.id)}
+      >
+        Acheter
+      </button>
+    </div>
+  );
+}

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  label: string;
+  value: string | number;
+}
+
+export default function StatCard({ label, value }: Props) {
+  return (
+    <div className="bg-white shadow rounded p-4 text-center">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="text-xl font-bold">{value}</div>
+    </div>
+  );
+}

--- a/src/pages/Habits.tsx
+++ b/src/pages/Habits.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useHabitsStore } from '../store/habitsStore';
+import HabitCard from '../components/HabitCard';
+import EmptyState from '../components/EmptyState';
+import { Difficulty, Frequency } from '../types';
+
+export default function Habits() {
+  const habits = useHabitsStore(s => s.habits);
+  const addHabit = useHabitsStore(s => s.addHabit);
+  const [form, setForm] = useState({ name: '', difficulty: 'Easy' as Difficulty, frequency: 'Daily' as Frequency, target: '' });
+
+  const submit = () => {
+    if (!form.name) return;
+    addHabit({ name: form.name, difficulty: form.difficulty, frequency: form.frequency, target: form.target });
+    setForm({ name: '', difficulty: 'Easy', frequency: 'Daily', target: '' });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white p-4 rounded shadow">
+        <h2 className="font-semibold mb-2">Nouvelle habitude</h2>
+        <input className="border p-2 w-full mb-2" placeholder="Nom" value={form.name} onChange={e=>setForm({...form, name:e.target.value})} />
+        <div className="flex space-x-2 mb-2">
+          <select className="border p-2" value={form.difficulty} onChange={e=>setForm({...form, difficulty:e.target.value as Difficulty})}>
+            <option>Easy</option>
+            <option>Medium</option>
+            <option>Hard</option>
+          </select>
+          <select className="border p-2" value={form.frequency} onChange={e=>setForm({...form, frequency:e.target.value as Frequency})}>
+            <option>Daily</option>
+            <option>Weekly</option>
+          </select>
+        </div>
+        <input className="border p-2 w-full mb-2" placeholder="Cible (optionnel)" value={form.target} onChange={e=>setForm({...form, target:e.target.value})} />
+        <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={submit}>Ajouter</button>
+      </div>
+      {habits.length === 0 ? <EmptyState message="Pas d'habitudes" /> : habits.map(h => <HabitCard key={h.id} habit={h} />)}
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import { useGameStore } from '../store/gameStore';
+import { useState } from 'react';
+
+export default function Home() {
+  const player = useGameStore(s => s.player);
+  const setName = useGameStore(s => s.setName);
+  const [temp, setTemp] = useState('');
+
+  if (!player.name) {
+    return (
+      <div className="space-y-2">
+        <p>Choisis un pseudo :</p>
+        <input className="border p-2 w-full" value={temp} onChange={e=>setTemp(e.target.value)} />
+        <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={()=>setName(temp)}>Valider</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      <Link to="/habits" className="bg-white shadow rounded p-4 text-center">Créer une habitude</Link>
+      <Link to="/quests" className="bg-white shadow rounded p-4 text-center">Voir quêtes du jour</Link>
+      <Link to="/shop" className="bg-white shadow rounded p-4 text-center">Boutique</Link>
+    </div>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,35 @@
+import { useGameStore } from '../store/gameStore';
+import { useHabitsStore } from '../store/habitsStore';
+import StatCard from '../components/StatCard';
+import { useState } from 'react';
+
+export default function Profile() {
+  const player = useGameStore(s => s.player);
+  const setName = useGameStore(s => s.setName);
+  const [name, setNameLocal] = useState(player.name);
+  const habits = useHabitsStore(s => s.habits);
+
+  const saveName = () => setName(name);
+  const completedThisWeek = habits.filter(h => h.lastCompletedAt && (Date.now() - h.lastCompletedAt) / 86400000 < 7).length;
+  const bestStreak = Math.max(0, ...habits.map(h => h.streak));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-4">
+        <div className="w-24 h-24 bg-gray-300 rounded-full" />
+        <div>
+          <input className="border p-2" value={name} onChange={e=>setNameLocal(e.target.value)} />
+          <button className="ml-2 px-3 py-1 bg-blue-500 text-white rounded" onClick={saveName}>Sauver</button>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <StatCard label="Niveau" value={player.level} />
+        <StatCard label="XP" value={player.xp} />
+        <StatCard label="Gold" value={player.gold} />
+        <StatCard label="HP" value={player.hp} />
+        <StatCard label="Habits semaine" value={completedThisWeek} />
+        <StatCard label="Meilleur streak" value={bestStreak} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Quests.tsx
+++ b/src/pages/Quests.tsx
@@ -1,0 +1,23 @@
+import { useQuestsStore } from '../store/questsStore';
+import QuestCard from '../components/QuestCard';
+import EmptyState from '../components/EmptyState';
+
+export default function Quests() {
+  const quests = useQuestsStore(s => s.questsToday);
+  const reroll = useQuestsStore(s => s.rerollQuests);
+  const rerollUsed = useQuestsStore(s => s.rerollUsed);
+
+  return (
+    <div className="space-y-4">
+      <button
+        aria-label="Reroll"
+        className="px-3 py-1 bg-yellow-500 text-white rounded"
+        onClick={reroll}
+        disabled={rerollUsed}
+      >
+        Reroll (3g)
+      </button>
+      {quests.length === 0 ? <EmptyState message="Pas de quêtes" /> : quests.map(q => <QuestCard key={q.id} quest={q} />)}
+    </div>
+  );
+}

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -1,0 +1,12 @@
+import { useShopStore } from '../store/shopStore';
+import ShopItemCard from '../components/ShopItemCard';
+
+export default function Shop() {
+  const catalog = useShopStore(s => s.catalog);
+  return (
+    <div className="grid gap-4">
+      {catalog.skins.map(item => <ShopItemCard key={item.id} item={item} />)}
+      {catalog.boosts.map(item => <ShopItemCard key={item.id} item={item} />)}
+    </div>
+  );
+}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,0 +1,103 @@
+import create from 'zustand';
+import { Player } from '../types';
+import { load, save } from '../utils/storage';
+import { xpNeeded } from '../utils/xp';
+import { todayKey, isNewDay } from '../utils/dates';
+
+interface GameState {
+  player: Player & { lastActive?: string };
+  setName: (name: string) => void;
+  gainXP: (amount: number) => void;
+  gainGold: (amount: number) => void;
+  takeDamage: (amount: number) => void;
+  spendGold: (amount: number) => boolean;
+  buySkin: (skin: string, cost: number) => void;
+  activateXpBoost: () => void;
+  isXpBoostActive: () => boolean;
+  dailyDecayIfIdle: () => void;
+}
+
+const defaultPlayer: Player & { lastActive?: string } = {
+  name: 'Aventurier',
+  level: 1,
+  xp: 0,
+  gold: 10,
+  hp: 100,
+  maxHp: 100,
+  boosts: {},
+  lastActive: todayKey(),
+};
+
+export const useGameStore = create<GameState>((set, get) => ({
+  player: load<Player & { lastActive?: string }>('player', defaultPlayer),
+  setName(name) {
+    const player = { ...get().player, name };
+    set({ player });
+    save('player', player);
+  },
+  gainXP(amount) {
+    const { player } = get();
+    const boost = get().isXpBoostActive() ? 1.5 : 1;
+    let newXp = player.xp + amount * boost;
+    let level = player.level;
+    let gold = player.gold;
+    while (newXp >= xpNeeded(level)) {
+      newXp -= xpNeeded(level);
+      level += 1;
+      gold += 10;
+    }
+    const updated = { ...player, xp: newXp, level, gold, lastActive: todayKey() };
+    set({ player: updated });
+    save('player', updated);
+  },
+  gainGold(amount) {
+    const player = { ...get().player, gold: get().player.gold + amount, lastActive: todayKey() };
+    set({ player });
+    save('player', player);
+  },
+  takeDamage(amount) {
+    const player = { ...get().player, hp: Math.max(0, get().player.hp - amount) };
+    set({ player });
+    save('player', player);
+  },
+  spendGold(amount) {
+    const { player } = get();
+    if (player.gold < amount) return false;
+    const updated = { ...player, gold: player.gold - amount };
+    set({ player: updated });
+    save('player', updated);
+    return true;
+  },
+  buySkin(skin, cost) {
+    if (get().spendGold(cost)) {
+      const player = { ...get().player, skin };
+      set({ player });
+      save('player', player);
+    }
+  },
+  activateXpBoost() {
+    if (get().spendGold(40)) {
+      const until = Date.now() + 24 * 60 * 60 * 1000;
+      const player = {
+        ...get().player,
+        boosts: { ...get().player.boosts, xp: { activeUntil: until } },
+      };
+      set({ player });
+      save('player', player);
+    }
+  },
+  isXpBoostActive() {
+    const until = get().player.boosts?.xp?.activeUntil;
+    return !!until && Date.now() < until;
+  },
+  dailyDecayIfIdle() {
+    const { player } = get();
+    if (isNewDay(player.lastActive)) {
+      player.hp = Math.max(0, player.hp - 5);
+      player.lastActive = todayKey();
+      const updated = { ...player };
+      set({ player: updated });
+      save('player', updated);
+    }
+  },
+}));

--- a/src/store/habitsStore.ts
+++ b/src/store/habitsStore.ts
@@ -1,0 +1,79 @@
+import create from 'zustand';
+import { Habit, Difficulty, Frequency } from '../types';
+import { load, save } from '../utils/storage';
+import { todayKey } from '../utils/dates';
+import { useGameStore } from './gameStore';
+
+interface HabitsState {
+  habits: Habit[];
+  addHabit: (habit: { name: string; difficulty: Difficulty; frequency: Frequency; target?: string }) => void;
+  updateHabit: (id: string, data: Partial<Habit>) => void;
+  deleteHabit: (id: string) => void;
+  toggleCompleteToday: (id: string) => void;
+  resetDailyChecksIfNewDay: () => void;
+}
+
+const defaultHabits: Habit[] = [
+  { id: 'h1', name: 'Boire 2L d\'eau', difficulty: 'Easy', frequency: 'Daily', createdAt: Date.now(), streak: 0 },
+  { id: 'h2', name: 'Lire 10 pages', difficulty: 'Medium', frequency: 'Daily', createdAt: Date.now(), streak: 0 },
+  { id: 'h3', name: 'Faire du sport', difficulty: 'Hard', frequency: 'Weekly', createdAt: Date.now(), streak: 0 },
+];
+
+export const useHabitsStore = create<HabitsState>((set, get) => ({
+  habits: load<Habit[]>('habits', defaultHabits),
+  addHabit(habit) {
+    const newHabit: Habit = {
+      ...habit,
+      id: crypto.randomUUID(),
+      createdAt: Date.now(),
+      streak: 0,
+    };
+    const habits = [...get().habits, newHabit];
+    set({ habits });
+    save('habits', habits);
+  },
+  updateHabit(id, data) {
+    const habits = get().habits.map(h => (h.id === id ? { ...h, ...data } : h));
+    set({ habits });
+    save('habits', habits);
+  },
+  deleteHabit(id) {
+    const habits = get().habits.filter(h => h.id !== id);
+    set({ habits });
+    save('habits', habits);
+  },
+  toggleCompleteToday(id) {
+    const key = todayKey();
+    const habits = get().habits.map(h => {
+      if (h.id !== id) return h;
+      const lastKey = h.lastCompletedAt ? new Date(h.lastCompletedAt).toISOString().slice(0, 10) : undefined;
+      if (lastKey === key) return h;
+      const multiplier = h.difficulty === 'Easy' ? 1 : h.difficulty === 'Medium' ? 1.5 : 2;
+      useGameStore.getState().gainXP(10 * multiplier);
+      useGameStore.getState().gainGold(2);
+      let streak = 1;
+      if (lastKey) {
+        const diff = Math.floor((Date.now() - h.lastCompletedAt!) / 86400000);
+        streak = diff === 1 ? h.streak + 1 : 1;
+      }
+      return { ...h, lastCompletedAt: Date.now(), streak };
+    });
+    set({ habits });
+    save('habits', habits);
+  },
+  resetDailyChecksIfNewDay() {
+    const key = todayKey();
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yKey = yesterday.toISOString().slice(0, 10);
+    const habits = get().habits.map(h => {
+      const lastKey = h.lastCompletedAt ? new Date(h.lastCompletedAt).toISOString().slice(0, 10) : undefined;
+      if (lastKey && lastKey !== key && lastKey !== yKey) {
+        return { ...h, streak: 0 };
+      }
+      return h;
+    });
+    set({ habits });
+    save('habits', habits);
+  },
+}));

--- a/src/store/questsStore.ts
+++ b/src/store/questsStore.ts
@@ -1,0 +1,87 @@
+import create from 'zustand';
+import { Quest } from '../types';
+import { load, save } from '../utils/storage';
+import { todayKey, isNewDay } from '../utils/dates';
+import { sampleSize } from '../utils/rng';
+import { useGameStore } from './gameStore';
+
+interface QuestTemplate {
+  title: string;
+  description: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+}
+
+const questPool: QuestTemplate[] = [
+  { title: 'Boire 2L d\'eau', description: 'Reste hydraté', difficulty: 'Easy' },
+  { title: 'Marcher 5 000 pas', description: 'Bouge un peu', difficulty: 'Medium' },
+  { title: 'Lire 10 minutes', description: 'Ouvre un livre', difficulty: 'Easy' },
+  { title: 'Méditer 5 minutes', description: 'Respire', difficulty: 'Easy' },
+  { title: '20 squats', description: 'Renforce tes jambes', difficulty: 'Medium' },
+  { title: '10 pompes', description: 'Renforce le haut du corps', difficulty: 'Medium' },
+  { title: 'Ranger 10 minutes', description: 'Espace propre', difficulty: 'Easy' },
+  { title: 'Écrire 3 gratitudes', description: 'Pensée positive', difficulty: 'Easy' },
+  { title: 'Pas d\'écran 30 min avant dodo', description: 'Détends-toi', difficulty: 'Hard' },
+  { title: '5 fruits & légumes', description: 'Mange sainement', difficulty: 'Medium' },
+  { title: '10 minutes d\'apprentissage', description: 'Apprends quelque chose', difficulty: 'Easy' },
+  { title: 'Appeler un proche', description: 'Reste connecté', difficulty: 'Easy' },
+];
+
+interface QuestsState {
+  todayDateKey: string;
+  questsToday: Quest[];
+  rerollUsed: boolean;
+  generateDailyQuests: () => void;
+  rerollQuests: () => void;
+  completeQuest: (id: string) => void;
+  ensureDailyQuests: () => void;
+}
+
+const stored = load<{ todayDateKey: string; questsToday: Quest[]; rerollUsed: boolean }>('quests', {
+  todayDateKey: todayKey(),
+  questsToday: [],
+  rerollUsed: false,
+});
+
+export const useQuestsStore = create<QuestsState>((set, get) => ({
+  todayDateKey: stored.todayDateKey,
+  questsToday: stored.questsToday,
+  rerollUsed: stored.rerollUsed,
+  generateDailyQuests() {
+    const today = todayKey();
+    const templates = sampleSize(questPool, 3);
+    const quests = templates.map(t => ({
+      id: crypto.randomUUID(),
+      title: t.title,
+      description: t.description,
+      difficulty: t.difficulty,
+      completed: false,
+    }));
+    set({ todayDateKey: today, questsToday: quests, rerollUsed: false });
+    save('quests', { todayDateKey: today, questsToday: quests, rerollUsed: false });
+  },
+  rerollQuests() {
+    if (get().rerollUsed) return;
+    if (useGameStore.getState().spendGold(3)) {
+      get().generateDailyQuests();
+      set({ rerollUsed: true });
+      const { todayDateKey, questsToday } = get();
+      save('quests', { todayDateKey, questsToday, rerollUsed: true });
+    }
+  },
+  completeQuest(id) {
+    const quests = get().questsToday.map(q => {
+      if (q.id !== id || q.completed) return q;
+      const mult = q.difficulty === 'Easy' ? 1 : q.difficulty === 'Medium' ? 1.5 : 2;
+      useGameStore.getState().gainXP(15 * mult);
+      useGameStore.getState().gainGold(5);
+      return { ...q, completed: true };
+    });
+    set({ questsToday: quests });
+    save('quests', { todayDateKey: get().todayDateKey, questsToday: quests, rerollUsed: get().rerollUsed });
+  },
+  ensureDailyQuests() {
+    if (isNewDay(get().todayDateKey)) {
+      get().generateDailyQuests();
+    }
+  },
+}));

--- a/src/store/shopStore.ts
+++ b/src/store/shopStore.ts
@@ -1,0 +1,45 @@
+import create from 'zustand';
+import { useGameStore } from './gameStore';
+
+interface ShopItem {
+  id: string;
+  name: string;
+  cost: number;
+  type: 'skin' | 'boost';
+}
+
+interface ShopState {
+  catalog: {
+    skins: ShopItem[];
+    boosts: ShopItem[];
+  };
+  canAfford: (cost: number) => boolean;
+  purchase: (id: string) => void;
+}
+
+const skins: ShopItem[] = [
+  { id: 'skin-forest', name: 'Forest Cloak', cost: 20, type: 'skin' },
+  { id: 'skin-knight', name: 'Knight Armor', cost: 50, type: 'skin' },
+  { id: 'skin-mystic', name: 'Mystic Pet', cost: 80, type: 'skin' },
+];
+
+const boosts: ShopItem[] = [
+  { id: 'boost-xp', name: 'XP Boost (x1.5, 24h)', cost: 40, type: 'boost' },
+];
+
+export const useShopStore = create<ShopState>(() => ({
+  catalog: { skins, boosts },
+  canAfford(cost) {
+    return useGameStore.getState().player.gold >= cost;
+  },
+  purchase(id) {
+    const item = skins.concat(boosts).find(i => i.id === id);
+    if (!item) return;
+    if (item.type === 'skin') {
+      useGameStore.getState().buySkin(item.name, item.cost);
+    }
+    if (item.type === 'boost') {
+      useGameStore.getState().activateXpBoost();
+    }
+  },
+}));

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,35 @@
+export type Difficulty = 'Easy' | 'Medium' | 'Hard';
+export type Frequency = 'Daily' | 'Weekly';
+
+export interface Habit {
+  id: string;
+  name: string;
+  category?: string;
+  difficulty: Difficulty;
+  frequency: Frequency;
+  target?: string;
+  createdAt: number;
+  lastCompletedAt?: number;
+  streak: number;
+}
+
+export interface Quest {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: Difficulty;
+  completed: boolean;
+}
+
+export interface Player {
+  name: string;
+  level: number;
+  xp: number;
+  gold: number;
+  hp: number;
+  maxHp: number;
+  skin?: string;
+  boosts?: {
+    xp?: { activeUntil?: number };
+  };
+}

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,7 @@
+export function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function isNewDay(lastKey?: string): boolean {
+  return lastKey !== todayKey();
+}

--- a/src/utils/rng.ts
+++ b/src/utils/rng.ts
@@ -1,0 +1,17 @@
+export function randomInt(max: number): number {
+  return Math.floor(Math.random() * max);
+}
+
+export function sample<T>(arr: T[]): T {
+  return arr[randomInt(arr.length)];
+}
+
+export function sampleSize<T>(arr: T[], size: number): T[] {
+  const copy = [...arr];
+  const result: T[] = [];
+  while (copy.length && result.length < size) {
+    const idx = randomInt(copy.length);
+    result.push(copy.splice(idx, 1)[0]);
+  }
+  return result;
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,12 @@
+export function load<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function save<T>(key: string, value: T): void {
+  localStorage.setItem(key, JSON.stringify(value));
+}

--- a/src/utils/xp.ts
+++ b/src/utils/xp.ts
@@ -1,0 +1,3 @@
+export function xpNeeded(level: number): number {
+  return 100 + (level - 1) * 25;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React 18 + TypeScript + Vite starter for Habit RPG game
- add Zustand stores for player, habits, quests and shop with localStorage persistence
- implement basic pages, components, tailwind config and utilities

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6bbc08ee4832f911ad3a138eeaa95