### PR TITLE
doc: explain how to avoid MIME errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ npm run dev
 - `npm run preview` : prévisualisation du build
 - `npm run lint` : vérifie le code avec ESLint
 
+## Problèmes courants
+
+Si vous ouvrez `index.html` directement via un fichier local ou un serveur statique, le navigateur ne peut pas interpréter les fichiers `.tsx` et renverra une erreur de type MIME. Pour éviter cela, lancez le serveur de développement Vite :
+
+```bash
+npm run dev
+```
+
+Ou générez le build puis prévisualisez-le :
+
+```bash
+npm run build
+npm run preview
+```
+
 ## Gameplay
 
 - Créez des habitudes et complétez des quêtes quotidiennes pour gagner de l'XP et de l'or.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
+    "typescript-eslint": "^6.4.0",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.45.0",
     "eslint-plugin-react": "^7.33.0",


### PR DESCRIPTION
## Summary
- document how to avoid TypeScript MIME errors by using Vite's dev server or build preview
- add missing `typescript-eslint` dev dependency

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint' imported from eslint.config.js)*
- `npm install` *(fails: 403 Forbidden when fetching typescript-eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68c70f30649c832fbdd335977938315b